### PR TITLE
Add a dependabot ignore directive for `cryptography`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,6 +63,13 @@ updates:
       interval: weekly
 
   - directory: /src
+    ignore:
+      # We should ignore updates to this dependency as long as we are installing the
+      # Alpine Linux py3-cryptography package in the Dockerfile. Since the version of
+      # cryptography in the Pipfile.lock file must be kept in sync with the version of
+      # the py3-cryptography package, we cannot use dependabot updates for this
+      # dependency at this time.
+      - dependency-name: cryptography
     package-ecosystem: pip
     schedule:
       interval: weekly

--- a/src/Pipfile
+++ b/src/Pipfile
@@ -7,7 +7,8 @@ name = "pypi"
 # Minimum version for IMDSv2 support
 boto3 = ">=1.13.23"
 # We need to use the system package version of this package. This matches the version
-# available for Alpine Linux 3.23.
+# available for Alpine Linux 3.23. We must also ignore dependabot updates for this
+# dependency as long as we are using the system package.
 cryptography = "46.0.7"
 docopt = ">=0.6.2"
 # We need a bugfix for behavior in newer versions of cloc. Since there is not a


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds a dependabot ignore directive for the `cryptography` package to the `/src` configuration.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

We are using the `py3-cryptography` system package to install this dependency at this time. As a result we cannot get updates unless the system package is updated, so the dependabot-offered updates are unusable to us.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
